### PR TITLE
Make schemaVersion public

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 		.library(name: "LMDB", targets: ["LMDB"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/apple/swift-syntax.git", from: "600.0.0-latest"),
+		.package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
 	],
 	targets: [
 		.target(

--- a/Sources/EmpireMacros/IndexKeyRecordMacro.swift
+++ b/Sources/EmpireMacros/IndexKeyRecordMacro.swift
@@ -66,7 +66,7 @@ extension IndexKeyRecordMacro {
 
 		return try VariableDeclSyntax(
 			"""
-static var schemaVersion: Int { \(literal) }
+public static var schemaVersion: Int { \(literal) }
 """
 		)
 	}


### PR DESCRIPTION
I'm seeing errors when applying `@IndexKeyRecord` to a public model.

The other Macro generated properties are public so it seems like this one should be too.

Unrelated: moved `swift-syntax` to the new canonical repo location