### PR TITLE
Use Swift 6 for SPI documentation builds

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [Empire]
+      swift_version: 6.0


### PR DESCRIPTION
As Swift 6 is still in beta the default documentation build runs Swift 5.10, but this package needs Swift 6.

Ideally, this should be reverted once we switch the default documentation build to Swift 6, which will happen once it gets a full release.