### PR TITLE
update swift-syntax versions and ci jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
           swift package reset
           swift package resolve
           swift package resolve --version ${{ matrix.swift-syntax-version }} swift-syntax
-          set -o pipefail && xcodebuild -scheme Empire-Package -destination "${{ matrix.destination }}" test | xcbeautify
+          set -o pipefail && xcodebuild -scheme Empire-Package -destination "${{ matrix.destination }}" -configuration ${{ matrix.configuration }} test | xcbeautify
 
   linux_test:
     name: Test Linux
@@ -94,7 +94,7 @@ jobs:
           . ~/.local/share/swiftly/env.sh
           hash -r
           swiftly install --use ${{ matrix.swift-version }}
-      - name: Test
+      - name: Test Swift ${{ matrix.swift-version }} / swift-syntax ${{ matrix.swift-syntax-version }} / ${{ matrix.configuration }}
         run: |
           . ~/.local/share/swiftly/env.sh
           hash -r

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     name: Test
     runs-on: macOS-15
     env:
-      DEVELOPER_DIR: /Applications/Xcode_16.2.app
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode-version }}.app
     strategy:
       matrix:
         destination:
@@ -32,24 +32,74 @@ jobs:
           - "platform=tvOS Simulator,name=Apple TV"
           - "platform=watchOS Simulator,name=Apple Watch Series 10 (42mm)"
           - "platform=visionOS Simulator,name=Apple Vision Pro"
+        xcode-version:
+          - '16.0'
+          - '16.1'
+          - '16.2'
+          - '16.3'
+        swift-syntax-version:
+          - '600.0.0'
+          - '600.0.1'
+          - '601.0.0'
+          - '601.0.1'
+        configuration:
+          - 'debug'
+          - 'release'
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-      - name: Test platform ${{ matrix.destination }}
-        run: set -o pipefail && xcodebuild -scheme Empire-Package -destination "${{ matrix.destination }}" test | xcbeautify
+      - name: Test platform ${{ matrix.destination }} / Xcode ${{ matrix.xcode-version }} / swift-syntax ${{ matrix.swift-syntax-version }} / ${{ matrix.configuration }}
+        run: |
+          swift --version
+          swift package reset
+          swift package resolve
+          swift package resolve --version ${{ matrix.swift-syntax-version }} swift-syntax
+          set -o pipefail && xcodebuild -scheme Empire-Package -destination "${{ matrix.destination }}" test | xcbeautify
 
   linux_test:
     name: Test Linux
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        swift-version:
+          - '6.0.0'
+          - '6.0.1'
+          - '6.0.2'
+          - '6.0.3'
+          - '6.1.0'
+        swift-syntax-version:
+          - '600.0.0'
+          - '600.0.1'
+          - '601.0.0'
+          - '601.0.1'
+        configuration:
+          - 'debug'
+          - 'release'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           submodules: true
       - name: Install swiftly
-        run: curl -L https://swiftlang.github.io/swiftly/swiftly-install.sh | bash -s -- -y
-      - name: Install the latest Swift toolchain
-        run: swiftly install latest
+        run: |
+          curl -O https://download.swift.org/swiftly/linux/swiftly-$(uname -m).tar.gz
+          tar zxf swiftly-$(uname -m).tar.gz
+          ./swiftly init --quiet-shell-followup
+          . ~/.local/share/swiftly/env.sh
+          hash -r
+          sudo apt-get -y install libcurl4-openssl-dev pkg-config python3-lldb-13
+      - name: Install the ${{ matrix.swift-version }} Swift toolchain
+        run: |
+          . ~/.local/share/swiftly/env.sh
+          hash -r
+          swiftly install --use ${{ matrix.swift-version }}
       - name: Test
-        run: swift test
+        run: |
+          . ~/.local/share/swiftly/env.sh
+          hash -r
+          swift --version
+          swift package reset
+          swift package resolve
+          swift package resolve --version ${{ matrix.swift-syntax-version }} swift-syntax
+          swift test --configuration ${{ matrix.configuration }}

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "d7c18c7096793507cf73b3eaaf1209455dc740c7bb6919a1018edfe6052d35b3",
+  "originHash" : "a8c8fb128f5d359abf0b40a2558bd21c8d2f25709a6e550702aa49fae3a10168",
   "pins" : [
     {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "82a453c2dfa335c7e778695762438dfe72b328d2",
-        "version" : "600.0.0-prerelease-2024-07-24"
+        "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
+        "version" : "601.0.1"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
 		.library(name: "LMDB", targets: ["LMDB"]),
 	],
 	dependencies: [
-		.package(url: "https://github.com/swiftlang/swift-syntax.git", from: "600.0.0-latest"),
+		.package(url: "https://github.com/swiftlang/swift-syntax.git", "600.0.0"..<"602.0.0"),
 	],
 	targets: [
 		.target(


### PR DESCRIPTION
The current `package.swift` fails to fetch the latest versions of `swift-syntax`. We can update `package.swift` to accept a wider range of versions.

Our current `ci.yml` builds from Xcode 16.2 and one version of `swift-syntax` in one configuration. We can update `ci.yml` with an expanded testing matrix. We can now test the product of:

* Xcode
  * 16.0
  * 16.1
  * 16.2
  * 16.3
* swift-syntax
  * 600.0.0
  * 600.0.1
  * 601.0.0
  * 601.0.1
* configuration
  * debug
  * release

For linux builds we can switch directly over Swift toolchains:

* Swift
  * 6.0.0
  * 6.0.1
  * 6.0.2
  * 6.0.3
  * 6.1.0

The updates to `ci.yml` to switch over `swift-syntax` versions were inspired by [Swift-CowBox](https://github.com/Swift-CowBox/Swift-CowBox) and [swift-macro-compatibility-check ](https://github.com/Matejkob/swift-macro-compatibility-check).