### PR TITLE
add build for release configuration and update package access control

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           swift package reset
           swift package resolve
           swift package resolve --version ${{ matrix.swift-syntax-version }} swift-syntax
-          set -o pipefail && xcodebuild -scheme Empire-Package -destination "${{ matrix.destination }}" test | xcbeautify
+          set -o pipefail && xcodebuild -scheme Empire-Package -destination "${{ matrix.destination }}" -configuration ${{ matrix.configuration }} test | xcbeautify
 
   linux_test:
     name: Test Linux

--- a/Sources/EmpireSwiftData/DataStoreAdapter.swift
+++ b/Sources/EmpireSwiftData/DataStoreAdapter.swift
@@ -11,11 +11,11 @@ struct KeyValueRecord {
 }
 
 @available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
-final class DataStoreAdapter {
-	let configuration: Configuration
+final package class DataStoreAdapter {
+	package let configuration: Configuration
 	private let store: Store
 
-	init(_ configuration: Configuration, migrationPlan: (any SchemaMigrationPlan.Type)?) throws {
+	package init(_ configuration: Configuration, migrationPlan: (any SchemaMigrationPlan.Type)?) throws {
 		self.configuration = configuration
 		self.store = try Store(url: configuration.url)
 	}
@@ -23,27 +23,33 @@ final class DataStoreAdapter {
 
 @available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension DataStoreAdapter {
-	struct Configuration: DataStoreConfiguration {
-		typealias Store = DataStoreAdapter
+	package struct Configuration: DataStoreConfiguration {
+		package typealias Store = DataStoreAdapter
 
-		var name: String
-		var schema: Schema?
-		var url: URL
+		package var name: String
+		package var schema: Schema?
+		package var url: URL
+		
+		package init(name: String, schema: Schema? = nil, url: URL) {
+			self.name = name
+			self.schema = schema
+			self.url = url
+		}
 
-		func validate() throws {
+		package func validate() throws {
 		}
 	}
 }
 
 @available(macOS 15, iOS 18, tvOS 18, watchOS 11, visionOS 2, *)
 extension DataStoreAdapter: DataStore {
-	typealias Snapshot = DefaultSnapshot
+	package typealias Snapshot = DefaultSnapshot
 	
-	func fetch<T>(_ request: DataStoreFetchRequest<T>) throws -> DataStoreFetchResult<T, Snapshot> where T : PersistentModel {
+	package func fetch<T>(_ request: DataStoreFetchRequest<T>) throws -> DataStoreFetchResult<T, Snapshot> where T : PersistentModel {
 		throw DataStoreError.unsupportedFeature
 	}
 	
-	func save(_ request: DataStoreSaveChangesRequest<Snapshot>) throws -> DataStoreSaveChangesResult<Snapshot> {
+	package func save(_ request: DataStoreSaveChangesRequest<Snapshot>) throws -> DataStoreSaveChangesResult<Snapshot> {
 		for insert in request.inserted {
 			let entityName = insert.persistentIdentifier.entityName
 			let _ = schema.entitiesByName[entityName]
@@ -52,11 +58,11 @@ extension DataStoreAdapter: DataStore {
 		return DataStoreSaveChangesResult(for: identifier)
 	}
 
-	var identifier: String {
+	package var identifier: String {
 		"hello"
 	}
 	
-	var schema: Schema {
+	package var schema: Schema {
 		configuration.schema!
 	}
 }

--- a/Tests/EmpireSwiftDataTests/DataStoreAdapterTests.swift
+++ b/Tests/EmpireSwiftDataTests/DataStoreAdapterTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import SwiftData
 import Testing
 
-@testable import EmpireSwiftData
+import EmpireSwiftData
 
 @Model
 final class Item {


### PR DESCRIPTION
It looks like we lost the `configuration` we were passing in for `xcodebuild`. It looks like we were failing to build for `release`.

If we attempt to build `release` we saw an error from the `@Testable import` in `DataStoreAdapterTests`.

There are pros and cons to `@Testable` but I would generally follow the advice to migrate away if possible.[^1]

Migrating away from `@Testable` breaks tests because we are no longer seeing `internal` symbols. We can unbreak the tests by migrating those symbols to `package`.

A potential alternative to this would be to no longer test `release` builds. We could choose to build and test for `debug`. We could then build (and not test) `release`.

[^1]: https://forums.swift.org/t/pitch-swiftpm-testable-build-setting/75084/5