### PR TITLE
update linux action swift versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
           - '6.0.2'
           - '6.0.3'
           - '6.1.0'
+          - '6.1.1'
+          - '6.1.2'
         swift-syntax-version:
           - '600.0.0'
           - '600.0.1'
@@ -81,7 +83,7 @@ jobs:
         configuration:
           - "debug"
         include:
-          - swift-version: "6.1.0"
+          - swift-version: "6.1.2"
             swift-syntax-version: "601.0.1"
             configuration: "release"
     steps:


### PR DESCRIPTION
https://github.com/vanvoorden/Empire/actions/runs/15313598873

It looks like Swift released two patch updates on 6.1. We can update our GitHub action to add the new versions.